### PR TITLE
[Effie] DRView, View Factory 및 관련 타입 구현

### DIFF
--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		F437A51F29D40634004D38C8 /* DRPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A51E29D40634004D38C8 /* DRPoint.swift */; };
 		F437A52129D40710004D38C8 /* Randomizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52029D40710004D38C8 /* Randomizable.swift */; };
 		F437A52329D40826004D38C8 /* DRSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52229D40826004D38C8 /* DRSize.swift */; };
+		F437A52529D40883004D38C8 /* DRColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52429D40883004D38C8 /* DRColor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
 		F437A51E29D40634004D38C8 /* DRPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRPoint.swift; sourceTree = "<group>"; };
 		F437A52029D40710004D38C8 /* Randomizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Randomizable.swift; sourceTree = "<group>"; };
 		F437A52229D40826004D38C8 /* DRSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRSize.swift; sourceTree = "<group>"; };
+		F437A52429D40883004D38C8 /* DRColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRColor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +73,7 @@
 				F437A51C29D404FB004D38C8 /* DRID.swift */,
 				F437A51E29D40634004D38C8 /* DRPoint.swift */,
 				F437A52229D40826004D38C8 /* DRSize.swift */,
+				F437A52429D40883004D38C8 /* DRColor.swift */,
 				F412CAA929D15D1D0034F420 /* Main.storyboard */,
 				F412CAAC29D15D1D0034F420 /* Assets.xcassets */,
 				F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */,
@@ -155,6 +158,7 @@
 				F437A51F29D40634004D38C8 /* DRPoint.swift in Sources */,
 				F437A52129D40710004D38C8 /* Randomizable.swift in Sources */,
 				F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */,
+				F437A52529D40883004D38C8 /* DRColor.swift in Sources */,
 				F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */,
 				F437A52329D40826004D38C8 /* DRSize.swift in Sources */,
 			);

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -1,0 +1,363 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F412CAA329D15D1D0034F420 /* AppDelegate.swift */; };
+		F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F412CAA529D15D1D0034F420 /* SceneDelegate.swift */; };
+		F412CAA829D15D1D0034F420 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F412CAA729D15D1D0034F420 /* ViewController.swift */; };
+		F412CAAB29D15D1D0034F420 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F412CAA929D15D1D0034F420 /* Main.storyboard */; };
+		F412CAAD29D15D1D0034F420 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F412CAAC29D15D1D0034F420 /* Assets.xcassets */; };
+		F412CAB029D15D1D0034F420 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		F412CAA029D15D1D0034F420 /* DrawingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F412CAA329D15D1D0034F420 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		F412CAA529D15D1D0034F420 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		F412CAA729D15D1D0034F420 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		F412CAAA29D15D1D0034F420 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		F412CAAC29D15D1D0034F420 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F412CAAF29D15D1D0034F420 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		F412CAB129D15D1D0034F420 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F412CA9D29D15D1D0034F420 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		F412CA9729D15D1D0034F420 = {
+			isa = PBXGroup;
+			children = (
+				F412CAA229D15D1D0034F420 /* DrawingApp */,
+				F412CAA129D15D1D0034F420 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		F412CAA129D15D1D0034F420 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F412CAA029D15D1D0034F420 /* DrawingApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F412CAA229D15D1D0034F420 /* DrawingApp */ = {
+			isa = PBXGroup;
+			children = (
+				F412CAA329D15D1D0034F420 /* AppDelegate.swift */,
+				F412CAA529D15D1D0034F420 /* SceneDelegate.swift */,
+				F412CAA729D15D1D0034F420 /* ViewController.swift */,
+				F412CAA929D15D1D0034F420 /* Main.storyboard */,
+				F412CAAC29D15D1D0034F420 /* Assets.xcassets */,
+				F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */,
+				F412CAB129D15D1D0034F420 /* Info.plist */,
+			);
+			path = DrawingApp;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		F412CA9F29D15D1D0034F420 /* DrawingApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F412CAB429D15D1D0034F420 /* Build configuration list for PBXNativeTarget "DrawingApp" */;
+			buildPhases = (
+				F412CA9C29D15D1D0034F420 /* Sources */,
+				F412CA9D29D15D1D0034F420 /* Frameworks */,
+				F412CA9E29D15D1D0034F420 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DrawingApp;
+			productName = DrawingApp;
+			productReference = F412CAA029D15D1D0034F420 /* DrawingApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F412CA9829D15D1D0034F420 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1410;
+				LastUpgradeCheck = 1410;
+				TargetAttributes = {
+					F412CA9F29D15D1D0034F420 = {
+						CreatedOnToolsVersion = 14.1;
+					};
+				};
+			};
+			buildConfigurationList = F412CA9B29D15D1D0034F420 /* Build configuration list for PBXProject "DrawingApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F412CA9729D15D1D0034F420;
+			productRefGroup = F412CAA129D15D1D0034F420 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F412CA9F29D15D1D0034F420 /* DrawingApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F412CA9E29D15D1D0034F420 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F412CAB029D15D1D0034F420 /* LaunchScreen.storyboard in Resources */,
+				F412CAAD29D15D1D0034F420 /* Assets.xcassets in Resources */,
+				F412CAAB29D15D1D0034F420 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F412CA9C29D15D1D0034F420 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F412CAA829D15D1D0034F420 /* ViewController.swift in Sources */,
+				F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */,
+				F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		F412CAA929D15D1D0034F420 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F412CAAA29D15D1D0034F420 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F412CAAF29D15D1D0034F420 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		F412CAB229D15D1D0034F420 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		F412CAB329D15D1D0034F420 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		F412CAB529D15D1D0034F420 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Y67S3384LP;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = DrawingApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.effiethedev.DrawingApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		F412CAB629D15D1D0034F420 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Y67S3384LP;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = DrawingApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.effiethedev.DrawingApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F412CA9B29D15D1D0034F420 /* Build configuration list for PBXProject "DrawingApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F412CAB229D15D1D0034F420 /* Debug */,
+				F412CAB329D15D1D0034F420 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F412CAB429D15D1D0034F420 /* Build configuration list for PBXNativeTarget "DrawingApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F412CAB529D15D1D0034F420 /* Debug */,
+				F412CAB629D15D1D0034F420 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F412CA9829D15D1D0034F420 /* Project object */;
+}

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		F437A52729D408D3004D38C8 /* DRAlpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52629D408D3004D38C8 /* DRAlpha.swift */; };
 		F437A52929D40B19004D38C8 /* DRView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52829D40B19004D38C8 /* DRView.swift */; };
 		F437A52B29D40BB8004D38C8 /* ViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52A29D40BB8004D38C8 /* ViewFactory.swift */; };
+		F437A52D29D40C0A004D38C8 /* RandomViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52C29D40C0A004D38C8 /* RandomViewFactory.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +41,7 @@
 		F437A52629D408D3004D38C8 /* DRAlpha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRAlpha.swift; sourceTree = "<group>"; };
 		F437A52829D40B19004D38C8 /* DRView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRView.swift; sourceTree = "<group>"; };
 		F437A52A29D40BB8004D38C8 /* ViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFactory.swift; sourceTree = "<group>"; };
+		F437A52C29D40C0A004D38C8 /* RandomViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomViewFactory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 				F437A52629D408D3004D38C8 /* DRAlpha.swift */,
 				F437A52829D40B19004D38C8 /* DRView.swift */,
 				F437A52A29D40BB8004D38C8 /* ViewFactory.swift */,
+				F437A52C29D40C0A004D38C8 /* RandomViewFactory.swift */,
 				F412CAA929D15D1D0034F420 /* Main.storyboard */,
 				F412CAAC29D15D1D0034F420 /* Assets.xcassets */,
 				F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */,
@@ -172,6 +175,7 @@
 				F437A52529D40883004D38C8 /* DRColor.swift in Sources */,
 				F437A52B29D40BB8004D38C8 /* ViewFactory.swift in Sources */,
 				F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */,
+				F437A52D29D40C0A004D38C8 /* RandomViewFactory.swift in Sources */,
 				F437A52329D40826004D38C8 /* DRSize.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -216,6 +216,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeRight UIInterfaceOrientationLandscapeLeft";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeRight UIInterfaceOrientationLandscapeLeft";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -223,6 +225,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Debug;
 		};
@@ -270,12 +273,15 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeRight UIInterfaceOrientationLandscapeLeft";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeRight UIInterfaceOrientationLandscapeLeft";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				TARGETED_DEVICE_FAMILY = 2;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -293,7 +299,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -304,7 +310,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Debug;
 		};
@@ -321,7 +327,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -332,7 +338,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Release;
 		};

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		F437A51D29D404FB004D38C8 /* DRID.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A51C29D404FB004D38C8 /* DRID.swift */; };
 		F437A51F29D40634004D38C8 /* DRPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A51E29D40634004D38C8 /* DRPoint.swift */; };
 		F437A52129D40710004D38C8 /* Randomizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52029D40710004D38C8 /* Randomizable.swift */; };
+		F437A52329D40826004D38C8 /* DRSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52229D40826004D38C8 /* DRSize.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		F437A51C29D404FB004D38C8 /* DRID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRID.swift; sourceTree = "<group>"; };
 		F437A51E29D40634004D38C8 /* DRPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRPoint.swift; sourceTree = "<group>"; };
 		F437A52029D40710004D38C8 /* Randomizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Randomizable.swift; sourceTree = "<group>"; };
+		F437A52229D40826004D38C8 /* DRSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRSize.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +70,7 @@
 				F437A52029D40710004D38C8 /* Randomizable.swift */,
 				F437A51C29D404FB004D38C8 /* DRID.swift */,
 				F437A51E29D40634004D38C8 /* DRPoint.swift */,
+				F437A52229D40826004D38C8 /* DRSize.swift */,
 				F412CAA929D15D1D0034F420 /* Main.storyboard */,
 				F412CAAC29D15D1D0034F420 /* Assets.xcassets */,
 				F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */,
@@ -153,6 +156,7 @@
 				F437A52129D40710004D38C8 /* Randomizable.swift in Sources */,
 				F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */,
 				F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */,
+				F437A52329D40826004D38C8 /* DRSize.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		F412CAB029D15D1D0034F420 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */; };
 		F437A51D29D404FB004D38C8 /* DRID.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A51C29D404FB004D38C8 /* DRID.swift */; };
 		F437A51F29D40634004D38C8 /* DRPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A51E29D40634004D38C8 /* DRPoint.swift */; };
+		F437A52129D40710004D38C8 /* Randomizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52029D40710004D38C8 /* Randomizable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		F412CAB129D15D1D0034F420 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F437A51C29D404FB004D38C8 /* DRID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRID.swift; sourceTree = "<group>"; };
 		F437A51E29D40634004D38C8 /* DRPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRPoint.swift; sourceTree = "<group>"; };
+		F437A52029D40710004D38C8 /* Randomizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Randomizable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,6 +65,7 @@
 				F412CAA329D15D1D0034F420 /* AppDelegate.swift */,
 				F412CAA529D15D1D0034F420 /* SceneDelegate.swift */,
 				F412CAA729D15D1D0034F420 /* ViewController.swift */,
+				F437A52029D40710004D38C8 /* Randomizable.swift */,
 				F437A51C29D404FB004D38C8 /* DRID.swift */,
 				F437A51E29D40634004D38C8 /* DRPoint.swift */,
 				F412CAA929D15D1D0034F420 /* Main.storyboard */,
@@ -147,6 +150,7 @@
 				F437A51D29D404FB004D38C8 /* DRID.swift in Sources */,
 				F412CAA829D15D1D0034F420 /* ViewController.swift in Sources */,
 				F437A51F29D40634004D38C8 /* DRPoint.swift in Sources */,
+				F437A52129D40710004D38C8 /* Randomizable.swift in Sources */,
 				F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */,
 				F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */,
 			);

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		F437A52529D40883004D38C8 /* DRColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52429D40883004D38C8 /* DRColor.swift */; };
 		F437A52729D408D3004D38C8 /* DRAlpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52629D408D3004D38C8 /* DRAlpha.swift */; };
 		F437A52929D40B19004D38C8 /* DRView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52829D40B19004D38C8 /* DRView.swift */; };
+		F437A52B29D40BB8004D38C8 /* ViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52A29D40BB8004D38C8 /* ViewFactory.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		F437A52429D40883004D38C8 /* DRColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRColor.swift; sourceTree = "<group>"; };
 		F437A52629D408D3004D38C8 /* DRAlpha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRAlpha.swift; sourceTree = "<group>"; };
 		F437A52829D40B19004D38C8 /* DRView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRView.swift; sourceTree = "<group>"; };
+		F437A52A29D40BB8004D38C8 /* ViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewFactory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 				F437A52429D40883004D38C8 /* DRColor.swift */,
 				F437A52629D408D3004D38C8 /* DRAlpha.swift */,
 				F437A52829D40B19004D38C8 /* DRView.swift */,
+				F437A52A29D40BB8004D38C8 /* ViewFactory.swift */,
 				F412CAA929D15D1D0034F420 /* Main.storyboard */,
 				F412CAAC29D15D1D0034F420 /* Assets.xcassets */,
 				F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */,
@@ -167,6 +170,7 @@
 				F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */,
 				F437A52929D40B19004D38C8 /* DRView.swift in Sources */,
 				F437A52529D40883004D38C8 /* DRColor.swift in Sources */,
+				F437A52B29D40BB8004D38C8 /* ViewFactory.swift in Sources */,
 				F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */,
 				F437A52329D40826004D38C8 /* DRSize.swift in Sources */,
 			);

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		F437A52329D40826004D38C8 /* DRSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52229D40826004D38C8 /* DRSize.swift */; };
 		F437A52529D40883004D38C8 /* DRColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52429D40883004D38C8 /* DRColor.swift */; };
 		F437A52729D408D3004D38C8 /* DRAlpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52629D408D3004D38C8 /* DRAlpha.swift */; };
+		F437A52929D40B19004D38C8 /* DRView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52829D40B19004D38C8 /* DRView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		F437A52229D40826004D38C8 /* DRSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRSize.swift; sourceTree = "<group>"; };
 		F437A52429D40883004D38C8 /* DRColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRColor.swift; sourceTree = "<group>"; };
 		F437A52629D408D3004D38C8 /* DRAlpha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRAlpha.swift; sourceTree = "<group>"; };
+		F437A52829D40B19004D38C8 /* DRView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +79,7 @@
 				F437A52229D40826004D38C8 /* DRSize.swift */,
 				F437A52429D40883004D38C8 /* DRColor.swift */,
 				F437A52629D408D3004D38C8 /* DRAlpha.swift */,
+				F437A52829D40B19004D38C8 /* DRView.swift */,
 				F412CAA929D15D1D0034F420 /* Main.storyboard */,
 				F412CAAC29D15D1D0034F420 /* Assets.xcassets */,
 				F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */,
@@ -162,6 +165,7 @@
 				F437A51F29D40634004D38C8 /* DRPoint.swift in Sources */,
 				F437A52129D40710004D38C8 /* Randomizable.swift in Sources */,
 				F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */,
+				F437A52929D40B19004D38C8 /* DRView.swift in Sources */,
 				F437A52529D40883004D38C8 /* DRColor.swift in Sources */,
 				F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */,
 				F437A52329D40826004D38C8 /* DRSize.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		F437A52129D40710004D38C8 /* Randomizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52029D40710004D38C8 /* Randomizable.swift */; };
 		F437A52329D40826004D38C8 /* DRSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52229D40826004D38C8 /* DRSize.swift */; };
 		F437A52529D40883004D38C8 /* DRColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52429D40883004D38C8 /* DRColor.swift */; };
+		F437A52729D408D3004D38C8 /* DRAlpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A52629D408D3004D38C8 /* DRAlpha.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		F437A52029D40710004D38C8 /* Randomizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Randomizable.swift; sourceTree = "<group>"; };
 		F437A52229D40826004D38C8 /* DRSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRSize.swift; sourceTree = "<group>"; };
 		F437A52429D40883004D38C8 /* DRColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRColor.swift; sourceTree = "<group>"; };
+		F437A52629D408D3004D38C8 /* DRAlpha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRAlpha.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,6 +76,7 @@
 				F437A51E29D40634004D38C8 /* DRPoint.swift */,
 				F437A52229D40826004D38C8 /* DRSize.swift */,
 				F437A52429D40883004D38C8 /* DRColor.swift */,
+				F437A52629D408D3004D38C8 /* DRAlpha.swift */,
 				F412CAA929D15D1D0034F420 /* Main.storyboard */,
 				F412CAAC29D15D1D0034F420 /* Assets.xcassets */,
 				F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */,
@@ -155,6 +158,7 @@
 			files = (
 				F437A51D29D404FB004D38C8 /* DRID.swift in Sources */,
 				F412CAA829D15D1D0034F420 /* ViewController.swift in Sources */,
+				F437A52729D408D3004D38C8 /* DRAlpha.swift in Sources */,
 				F437A51F29D40634004D38C8 /* DRPoint.swift in Sources */,
 				F437A52129D40710004D38C8 /* Randomizable.swift in Sources */,
 				F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		F412CAAB29D15D1D0034F420 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F412CAA929D15D1D0034F420 /* Main.storyboard */; };
 		F412CAAD29D15D1D0034F420 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F412CAAC29D15D1D0034F420 /* Assets.xcassets */; };
 		F412CAB029D15D1D0034F420 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */; };
+		F437A51D29D404FB004D38C8 /* DRID.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A51C29D404FB004D38C8 /* DRID.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +25,7 @@
 		F412CAAC29D15D1D0034F420 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F412CAAF29D15D1D0034F420 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F412CAB129D15D1D0034F420 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F437A51C29D404FB004D38C8 /* DRID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRID.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 				F412CAA329D15D1D0034F420 /* AppDelegate.swift */,
 				F412CAA529D15D1D0034F420 /* SceneDelegate.swift */,
 				F412CAA729D15D1D0034F420 /* ViewController.swift */,
+				F437A51C29D404FB004D38C8 /* DRID.swift */,
 				F412CAA929D15D1D0034F420 /* Main.storyboard */,
 				F412CAAC29D15D1D0034F420 /* Assets.xcassets */,
 				F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */,
@@ -138,6 +141,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F437A51D29D404FB004D38C8 /* DRID.swift in Sources */,
 				F412CAA829D15D1D0034F420 /* ViewController.swift in Sources */,
 				F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */,
 				F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */,

--- a/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingApp/DrawingApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		F412CAAD29D15D1D0034F420 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F412CAAC29D15D1D0034F420 /* Assets.xcassets */; };
 		F412CAB029D15D1D0034F420 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */; };
 		F437A51D29D404FB004D38C8 /* DRID.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A51C29D404FB004D38C8 /* DRID.swift */; };
+		F437A51F29D40634004D38C8 /* DRPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F437A51E29D40634004D38C8 /* DRPoint.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		F412CAAF29D15D1D0034F420 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F412CAB129D15D1D0034F420 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F437A51C29D404FB004D38C8 /* DRID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRID.swift; sourceTree = "<group>"; };
+		F437A51E29D40634004D38C8 /* DRPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRPoint.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 				F412CAA529D15D1D0034F420 /* SceneDelegate.swift */,
 				F412CAA729D15D1D0034F420 /* ViewController.swift */,
 				F437A51C29D404FB004D38C8 /* DRID.swift */,
+				F437A51E29D40634004D38C8 /* DRPoint.swift */,
 				F412CAA929D15D1D0034F420 /* Main.storyboard */,
 				F412CAAC29D15D1D0034F420 /* Assets.xcassets */,
 				F412CAAE29D15D1D0034F420 /* LaunchScreen.storyboard */,
@@ -143,6 +146,7 @@
 			files = (
 				F437A51D29D404FB004D38C8 /* DRID.swift in Sources */,
 				F412CAA829D15D1D0034F420 /* ViewController.swift in Sources */,
+				F437A51F29D40634004D38C8 /* DRPoint.swift in Sources */,
 				F412CAA429D15D1D0034F420 /* AppDelegate.swift in Sources */,
 				F412CAA629D15D1D0034F420 /* SceneDelegate.swift in Sources */,
 			);

--- a/DrawingApp/DrawingApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/DrawingApp/DrawingApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/DrawingApp/DrawingApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/DrawingApp/DrawingApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/DrawingApp/DrawingApp.xcodeproj/xcshareddata/xcschemes/DrawingApp.xcscheme
+++ b/DrawingApp/DrawingApp.xcodeproj/xcshareddata/xcschemes/DrawingApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F412CA9F29D15D1D0034F420"
+               BuildableName = "DrawingApp.app"
+               BlueprintName = "DrawingApp"
+               ReferencedContainer = "container:DrawingApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F412CA9F29D15D1D0034F420"
+            BuildableName = "DrawingApp.app"
+            BlueprintName = "DrawingApp"
+            ReferencedContainer = "container:DrawingApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F412CA9F29D15D1D0034F420"
+            BuildableName = "DrawingApp.app"
+            BlueprintName = "DrawingApp"
+            ReferencedContainer = "container:DrawingApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DrawingApp/DrawingApp/AppDelegate.swift
+++ b/DrawingApp/DrawingApp/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/27.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Override point for customization after application launch.
+    return true
+  }
+
+  // MARK: UISceneSession Lifecycle
+
+  func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    // Called when a new scene session is being created.
+    // Use this method to select a configuration to create the new scene with.
+    return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+
+  func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    // Called when the user discards a scene session.
+    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+  }
+
+
+}
+

--- a/DrawingApp/DrawingApp/AppDelegate.swift
+++ b/DrawingApp/DrawingApp/AppDelegate.swift
@@ -9,28 +9,13 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
+  
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    // Override point for customization after application launch.
     return true
   }
 
-  // MARK: UISceneSession Lifecycle
-
   func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-    // Called when a new scene session is being created.
-    // Use this method to select a configuration to create the new scene with.
     return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
   }
-
-  func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-    // Called when the user discards a scene session.
-    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-  }
-
-
 }
 

--- a/DrawingApp/DrawingApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/DrawingApp/DrawingApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DrawingApp/DrawingApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/DrawingApp/DrawingApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DrawingApp/DrawingApp/Assets.xcassets/Contents.json
+++ b/DrawingApp/DrawingApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DrawingApp/DrawingApp/Base.lproj/LaunchScreen.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
+++ b/DrawingApp/DrawingApp/Base.lproj/Main.storyboard
@@ -1,24 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="ipad11_0rounded" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="DrawingApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1194" height="834"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="83" y="-34"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/DrawingApp/DrawingApp/DRAlpha.swift
+++ b/DrawingApp/DrawingApp/DRAlpha.swift
@@ -1,0 +1,37 @@
+//
+//  DRAlpha.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/29.
+//
+
+import Foundation
+
+struct DRAlpha: CustomStringConvertible {
+  typealias Figure = Level
+  
+  enum Level: Int, CaseIterable {
+    case lv1 = 1
+    case lv2
+    case lv3
+    case lv4
+    case lv5
+    case lv6
+    case lv7
+    case lv8
+    case lv9
+    case lv10
+  }
+  
+  private let level: Level
+  
+  init(level: Level) {
+    self.level = level
+  }
+  
+  // MARK: CustomStringConvertible
+  
+  var description: String {
+    "Alpha: \(level.rawValue)"
+  }
+}

--- a/DrawingApp/DrawingApp/DRAlpha.swift
+++ b/DrawingApp/DrawingApp/DRAlpha.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 struct DRAlpha: CustomStringConvertible, Randomizable {
-  typealias Figure = Level
-  
   enum Level: Int, CaseIterable, Comparable {
     case lv1 = 1
     case lv2
@@ -26,6 +24,8 @@ struct DRAlpha: CustomStringConvertible, Randomizable {
       lhs.rawValue < rhs.rawValue
     }
   }
+  
+  typealias Figure = Level
   
   private let level: Level
   

--- a/DrawingApp/DrawingApp/DRAlpha.swift
+++ b/DrawingApp/DrawingApp/DRAlpha.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-struct DRAlpha: CustomStringConvertible {
+struct DRAlpha: CustomStringConvertible, Randomizable {
   typealias Figure = Level
   
-  enum Level: Int, CaseIterable {
+  enum Level: Int, CaseIterable, Comparable {
     case lv1 = 1
     case lv2
     case lv3
@@ -21,6 +21,10 @@ struct DRAlpha: CustomStringConvertible {
     case lv8
     case lv9
     case lv10
+    
+    static func < (lhs: DRAlpha.Level, rhs: DRAlpha.Level) -> Bool {
+      lhs.rawValue < rhs.rawValue
+    }
   }
   
   private let level: Level
@@ -33,5 +37,9 @@ struct DRAlpha: CustomStringConvertible {
   
   var description: String {
     "Alpha: \(level.rawValue)"
+  }
+  
+  static func makeRandomFigure(range: ClosedRange<Figure>? = nil) -> Figure {
+    Figure.allCases.randomElement() ?? .lv10
   }
 }

--- a/DrawingApp/DrawingApp/DRColor.swift
+++ b/DrawingApp/DrawingApp/DRColor.swift
@@ -20,9 +20,13 @@ struct DRColor: Randomizable, CustomStringConvertible {
     self.blue = blue
   }
   
+  // MARK: CustomStringConvertible
+  
   var description: String {
     "R:\(red), G:\(green), B:\(blue)"
   }
+  
+  // MARK: Randomizable
   
   static func makeRandomFigure(range: ClosedRange<UInt8>? = nil) -> UInt8 {
     (0...UInt8.max).randomElement() ?? UInt8.min

--- a/DrawingApp/DrawingApp/DRColor.swift
+++ b/DrawingApp/DrawingApp/DRColor.swift
@@ -1,0 +1,30 @@
+//
+//  DRColor.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/29.
+//
+
+import Foundation
+
+struct DRColor: Randomizable, CustomStringConvertible {
+  typealias Figure = UInt8
+  
+  private let red: Figure
+  private let green: Figure
+  private let blue: Figure
+  
+  init(r red: UInt8, g green: UInt8, b blue: UInt8) {
+    self.red = red
+    self.green = green
+    self.blue = blue
+  }
+  
+  var description: String {
+    "R:\(red), G:\(green), B:\(blue)"
+  }
+  
+  static func makeRandomFigure(range: ClosedRange<UInt8>? = nil) -> UInt8 {
+    (0...UInt8.max).randomElement() ?? UInt8.min
+  }
+}

--- a/DrawingApp/DrawingApp/DRID.swift
+++ b/DrawingApp/DrawingApp/DRID.swift
@@ -7,9 +7,11 @@
 
 import Foundation
 
-struct DRID: Equatable, CustomStringConvertible {
+struct DRID: Equatable, Randomizable, CustomStringConvertible {
+  
+  typealias Figure = String
 
-  private let id: String
+  private let id: Figure
   
   init(id: String) {
     self.id = id
@@ -27,9 +29,11 @@ struct DRID: Equatable, CustomStringConvertible {
     id
   }
   
-  static func makeRandomID() -> String {
-    let componentLength = [3, 3, 3]
-    
+  // MARK: Randomizable
+  
+  static private let componentLength = [3, 3, 3]
+  
+  static func makeRandomFigure(range: ClosedRange<Figure>? = nil) -> Figure {
     var tempID = UUID().uuidString
     var result: String = ""
     

--- a/DrawingApp/DrawingApp/DRID.swift
+++ b/DrawingApp/DrawingApp/DRID.swift
@@ -1,0 +1,45 @@
+//
+//  DRID.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/29.
+//
+
+import Foundation
+
+struct DRID: Equatable, CustomStringConvertible {
+
+  private let id: String
+  
+  init(id: String) {
+    self.id = id
+  }
+  
+  // MARK: Equatable
+  
+  static func == (lhs: DRID, rhs: DRID) -> Bool {
+    lhs.id == rhs.id
+  }
+  
+  // MARK: CustomStringConvertible
+  
+  var description: String {
+    id
+  }
+  
+  static func makeRandomID() -> String {
+    let componentLength = [3, 3, 3]
+    
+    var tempID = UUID().uuidString
+    var result: String = ""
+    
+    for (index, length) in componentLength.enumerated() {
+      for _ in 0..<length {
+        guard let char = tempID.popLast() else { break }
+        result += String(char)
+      }
+      if index != componentLength.count - 1 { result.append("-") }
+    }
+    return result
+  }
+}

--- a/DrawingApp/DrawingApp/DRPoint.swift
+++ b/DrawingApp/DrawingApp/DRPoint.swift
@@ -1,0 +1,26 @@
+//
+//  DRPoint.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/29.
+//
+
+import Foundation
+
+struct DRPoint: CustomStringConvertible {
+  private let x: Double
+  private let y: Double
+  
+  init(x: Double, y: Double) {
+    self.x = x
+    self.y = y
+  }
+  
+  var description: String {
+    "X: \(Int(x)), Y: \(Int(y))"
+  }
+  
+  static func makeRandomFigure(upperBound: Double) -> Double {
+    return Double.random(in: (0 ... upperBound))
+  }
+}

--- a/DrawingApp/DrawingApp/DRPoint.swift
+++ b/DrawingApp/DrawingApp/DRPoint.swift
@@ -7,20 +7,27 @@
 
 import Foundation
 
-struct DRPoint: CustomStringConvertible {
-  private let x: Double
-  private let y: Double
+struct DRPoint: Randomizable, CustomStringConvertible {
+  typealias Figure = Double
+  
+  private let x: Figure
+  private let y: Figure
   
   init(x: Double, y: Double) {
     self.x = x
     self.y = y
   }
   
+  // MARK: CustomStringConvertible
+  
   var description: String {
     "X: \(Int(x)), Y: \(Int(y))"
   }
   
-  static func makeRandomFigure(upperBound: Double) -> Double {
-    return Double.random(in: (0 ... upperBound))
+  // MARK: Randomizable
+  
+  static func makeRandomFigure(range: ClosedRange<Figure>?) -> Figure {
+    guard let range else { return 0 }
+    return Double.random(in: range)
   }
 }

--- a/DrawingApp/DrawingApp/DRSize.swift
+++ b/DrawingApp/DrawingApp/DRSize.swift
@@ -1,0 +1,29 @@
+//
+//  DRSize.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/29.
+//
+
+import Foundation
+
+struct DRSize: Randomizable, CustomStringConvertible {
+  typealias Figure = Double
+  
+  private let width: Figure
+  private let height: Figure
+  
+  var description: String {
+    "W\(Int(width)), H\(Int(height))"
+  }
+  
+  init(width: Double, height: Double) {
+    self.width = width
+    self.height = height
+  }
+  
+  static func makeRandomFigure(range: ClosedRange<Figure>?) -> Figure {
+    guard let range else { return 100 }
+    return Double.random(in: range)
+  }
+}

--- a/DrawingApp/DrawingApp/DRSize.swift
+++ b/DrawingApp/DrawingApp/DRSize.swift
@@ -13,14 +13,18 @@ struct DRSize: Randomizable, CustomStringConvertible {
   private let width: Figure
   private let height: Figure
   
-  var description: String {
-    "W\(Int(width)), H\(Int(height))"
-  }
-  
   init(width: Double, height: Double) {
     self.width = width
     self.height = height
   }
+  
+  // MARK: CustomStringConvertible
+  
+  var description: String {
+    "W\(Int(width)), H\(Int(height))"
+  }
+  
+  // MARK: Randomizable
   
   static func makeRandomFigure(range: ClosedRange<Figure>?) -> Figure {
     guard let range else { return 100 }

--- a/DrawingApp/DrawingApp/DRView.swift
+++ b/DrawingApp/DrawingApp/DRView.swift
@@ -1,0 +1,40 @@
+//
+//  DRView.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/29.
+//
+
+import Foundation
+
+class DRView: Equatable, CustomStringConvertible {
+  private let id: DRID
+  
+  private var size: DRSize
+  
+  private var position: DRPoint
+  
+  private var backgroundColor: DRColor
+  
+  private var alpha: DRAlpha
+  
+  init(id: DRID, size: DRSize, position: DRPoint, backgroundColor: DRColor, alpha: DRAlpha) {
+    self.id = id
+    self.size = size
+    self.position = position
+    self.backgroundColor = backgroundColor
+    self.alpha = alpha
+  }
+  
+  // MARK: Equatable
+  
+  static func == (lhs: DRView, rhs: DRView) -> Bool {
+    lhs.id == rhs.id
+  }
+  
+  // MARK: CustomStringConvertible
+  
+  var description: String {
+    "(\(id.description)), \(position.description), \(size.description), \(backgroundColor.description), \(alpha.description)"
+  }
+}

--- a/DrawingApp/DrawingApp/Info.plist
+++ b/DrawingApp/DrawingApp/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/DrawingApp/DrawingApp/RandomViewFactory.swift
+++ b/DrawingApp/DrawingApp/RandomViewFactory.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 class RandomViewFactory: ViewFactory {
-  let xRange: ClosedRange<Double>
+  private let xRange: ClosedRange<Double>
   
-  let yRange: ClosedRange<Double>
+  private let yRange: ClosedRange<Double>
   
   init(xRange: ClosedRange<Double>, yRange: ClosedRange<Double>) {
     self.xRange = xRange
@@ -39,6 +39,8 @@ class RandomViewFactory: ViewFactory {
     let level = DRAlpha.makeRandomFigure()
     return .init(level: level)
   }
+  
+  // MARK: ViewFactory
   
   func makeView() -> DRView? {
       let id = makeRandomID()

--- a/DrawingApp/DrawingApp/RandomViewFactory.swift
+++ b/DrawingApp/DrawingApp/RandomViewFactory.swift
@@ -1,0 +1,51 @@
+//
+//  RandomViewFactory.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/29.
+//
+
+import Foundation
+
+class RandomViewFactory: ViewFactory {
+  let xRange: ClosedRange<Double>
+  
+  let yRange: ClosedRange<Double>
+  
+  init(xRange: ClosedRange<Double>, yRange: ClosedRange<Double>) {
+    self.xRange = xRange
+    self.yRange = yRange
+  }
+  
+  private func makeRandomID() -> DRID {
+    let randomString = DRID.makeRandomFigure()
+    return .init(id: randomString)
+  }
+  
+  private func makeRandomPosition() -> DRPoint {
+    let x = DRPoint.makeRandomFigure(range: xRange)
+    let y = DRPoint.makeRandomFigure(range: yRange)
+    return .init(x: x, y: y)
+  }
+  
+  private func makeRandomColor() -> DRColor {
+    let r = DRColor.makeRandomFigure()
+    let g = DRColor.makeRandomFigure()
+    let b = DRColor.makeRandomFigure()
+    return .init(r: r, g: g, b: b)
+  }
+  
+  private func makeRandomAlpha() -> DRAlpha {
+    let level = DRAlpha.makeRandomFigure()
+    return .init(level: level)
+  }
+  
+  func makeView() -> DRView? {
+      let id = makeRandomID()
+      let size = DRSize(width: 150, height: 120)
+      let position = makeRandomPosition()
+      let color = makeRandomColor()
+      let alpha = makeRandomAlpha()
+    return .init(id: id, size: size, position: position, backgroundColor: color, alpha: alpha)
+  }
+}

--- a/DrawingApp/DrawingApp/Randomizable.swift
+++ b/DrawingApp/DrawingApp/Randomizable.swift
@@ -1,0 +1,14 @@
+//
+//  Randomizable.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/29.
+//
+
+import Foundation
+
+protocol Randomizable {
+  associatedtype Figure: Comparable
+  
+  static func makeRandomFigure(range: ClosedRange<Figure>?) -> Figure
+}

--- a/DrawingApp/DrawingApp/SceneDelegate.swift
+++ b/DrawingApp/DrawingApp/SceneDelegate.swift
@@ -8,45 +8,6 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
   var window: UIWindow?
-
-
-  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-    guard let _ = (scene as? UIWindowScene) else { return }
-  }
-
-  func sceneDidDisconnect(_ scene: UIScene) {
-    // Called as the scene is being released by the system.
-    // This occurs shortly after the scene enters the background, or when its session is discarded.
-    // Release any resources associated with this scene that can be re-created the next time the scene connects.
-    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-  }
-
-  func sceneDidBecomeActive(_ scene: UIScene) {
-    // Called when the scene has moved from an inactive state to an active state.
-    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-  }
-
-  func sceneWillResignActive(_ scene: UIScene) {
-    // Called when the scene will move from an active state to an inactive state.
-    // This may occur due to temporary interruptions (ex. an incoming phone call).
-  }
-
-  func sceneWillEnterForeground(_ scene: UIScene) {
-    // Called as the scene transitions from the background to the foreground.
-    // Use this method to undo the changes made on entering the background.
-  }
-
-  func sceneDidEnterBackground(_ scene: UIScene) {
-    // Called as the scene transitions from the foreground to the background.
-    // Use this method to save data, release shared resources, and store enough scene-specific state information
-    // to restore the scene back to its current state.
-  }
-
-
 }
 

--- a/DrawingApp/DrawingApp/SceneDelegate.swift
+++ b/DrawingApp/DrawingApp/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/27.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+  var window: UIWindow?
+
+
+  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+    guard let _ = (scene as? UIWindowScene) else { return }
+  }
+
+  func sceneDidDisconnect(_ scene: UIScene) {
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+  }
+
+  func sceneDidBecomeActive(_ scene: UIScene) {
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+  }
+
+  func sceneWillResignActive(_ scene: UIScene) {
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+  }
+
+  func sceneWillEnterForeground(_ scene: UIScene) {
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+  }
+
+  func sceneDidEnterBackground(_ scene: UIScene) {
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+  }
+
+
+}
+

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -6,12 +6,28 @@
 //
 
 import UIKit
+import OSLog
 
 class ViewController: UIViewController {
+  
+  private var views = [DRView]()
 
   override func viewDidLoad() {
     super.viewDidLoad()
+    
+    let viewXRange = (0.0 ... Double(view.frame.width))
+    let viewYRange = (0.0 ... Double(view.frame.height))
+    
+    let randomFactory = RandomViewFactory(xRange: viewXRange, yRange: viewYRange)
+    makeViews(with: randomFactory, count: 4)
   }
-
+  
+  private func makeViews(with factory: ViewFactory, count: Int) {
+    let logger = Logger()
+    for i in 0..<count {
+      guard let newView = factory.makeView() else { continue }
+      views.append(newView)
+      logger.log("Rect\(i + 1) \(newView.description)")
+    }
+  }
 }
-

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -11,9 +11,7 @@ class ViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    // Do any additional setup after loading the view.
   }
-
 
 }
 

--- a/DrawingApp/DrawingApp/ViewController.swift
+++ b/DrawingApp/DrawingApp/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/27.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    // Do any additional setup after loading the view.
+  }
+
+
+}
+

--- a/DrawingApp/DrawingApp/ViewFactory.swift
+++ b/DrawingApp/DrawingApp/ViewFactory.swift
@@ -1,0 +1,12 @@
+//
+//  ViewFactory.swift
+//  DrawingApp
+//
+//  Created by Effie on 2023/03/29.
+//
+
+import Foundation
+
+protocol ViewFactory {
+  func makeView() -> DRView?
+}


### PR DESCRIPTION
## 🧩 주요 작업

step 1 요구사항에 맞게 View 클래스와, ViewFactory 프로토콜을 채용한 RandomViewFactory를 구현했습니다.

- [x]  DRView 구현
- [x]  view 관련 타입(DRID, DRPoint, DRSize, DRColor, DRAlpha) 선언
- [x]  타입과 관련된 랜덤 값을 생성하는 Randomizabel 인터페이스를 선언하고, 각 타입에서 구현
- [x]  ViewFactory의 인터페이스를 구현하는 RandomViewFactory 선언
- [x]  ViewController에서 팩토리를 생성하고 호출하는 코드 추가
- [x]  시스템 로거를 사용해 로그 출력하는 코드 추가

## 🧩 스크린샷

![view-factory](https://user-images.githubusercontent.com/56967908/228453201-0be2a814-b3f6-4cbb-b2ce-c21e838fda3c.gif)

## 🧩 기술 키워드

- 심플 팩토리 패턴
- 팩토리 메소드 패턴
- MVC(Model - View - View Controller) 패턴
- Logger
- ClosedRange

## 🧩 고민과 해결 과정

### 랜덤값을 위한 랜덤값을 생성하는 코드를 어디에 배치할까

미션에서는 view 인스턴스를 생성할 때 필요한 id, size, point, color 등의 속성 인스턴스를 생성하는 코드를 팩토리에서 구현하도록 요구하고 있다. 

그런데 이 속성 인스턴스를 생성할 때도 다시 랜덤값이 필요하다. 팩토리가 어디까지 하는 게 맞는 걸까…

- 랜덤값을 모두 팩토리에서 생성하자.
    
    → 팩토리가 너무 많은 역할을 하는 건 아닐까?
    
- 각 타입과 좀 더 관련이 있으니 각 타입에 타입 멤버를 추가해보자
    - 랜덤값을 만드는 메소드를 static 메소드로 추가하고,
    - 모든 타입에서 비슷한 기능을 구현하고 있으니, 이를 묶는 프로토콜을 만들자!
    - 그리고 각 타입에서 적절한 값을 만들 수 있도록 제네릭으로 만들자

### 뷰컨에서만 알 수 있는 정보를 랜덤값을 생성하는 곳까지 어떻게 전달할까?

윈도우의 크기를 알아야 뷰의 위치를 정할 수 있기 때문에 랜덤값을 만드려면 뷰컨에서 정보를 가져와야 하는데..

- 팩토리가 생성되는 시점에 정보를 가지고 오자
    - 팩토리가 랜덤값을 생성하는 메소드를 호출할 때 적절한 정보를 전달하려면 정보를 속성을 갖는 게 나을 것 같다.
    - 팩토리를 생성하는 시점에 뷰컨에서 정보를 전달하도록 이니셜라이저를 구현하자.
    - 랜덤 인스턴스를 생성하는 private 메소드에서 이 정보를 사용하도록 구현하자.